### PR TITLE
Enable drawing

### DIFF
--- a/application.py
+++ b/application.py
@@ -14,7 +14,16 @@ def home():
 
 @app.route('/create')
 def create():
-    return render_template('create.html')
+    return render_template('create.html', options=request.args.get('options', ''))
+
+
+@app.route('/create_boulder')
+def create_boulder():
+    return render_template('create_boulder.html')
+
+@app.route('/create_route')
+def create_route():
+    return render_template('create_route.html')
 
 
 @app.route('/explore')
@@ -29,8 +38,12 @@ def render_about_us():
 
 @app.route('/walls/<string:wall_section>')
 def wall_section(wall_section):
+    template = 'create_boulder.html' 
+    if request.args.get('options', '') == 'route':
+        template = 'create_route.html' 
+
     return render_template(
-        "show_wall.html",
+        template,
         user_image=url_for(
             'static',
             filename='{}{}.JPG'.format(WALLS_PATH, wall_section)

--- a/templates/create.html
+++ b/templates/create.html
@@ -23,12 +23,12 @@
           <br />
           <h3>Choose wall</h3>
           <br />
-          <p>&bull;<a href="/walls/sAll"> All sections</a></p>
-          <p>&bull;<a href="/walls/s1"> Section 1</a></p>
-          <p>&bull;<a href="/walls/s2"> Section 2</a></p>
-          <p>&bull;<a href="/walls/s3"> Section 3</a></p>
-          <p>&bull;<a href="/walls/s4"> Section 4</a></p>
-          <p>&bull;<a href="/walls/s5"> Section 5</a></p>
+          <p>&bull;<a href="/walls/sAll?options={{options}}"> All sections</a></p>
+          <p>&bull;<a href="/walls/s1?options={{options}}"> Section 1</a></p>
+          <p>&bull;<a href="/walls/s2?options={{options}}"> Section 2</a></p>
+          <p>&bull;<a href="/walls/s3?options={{options}}"> Section 3</a></p>
+          <p>&bull;<a href="/walls/s4?options={{options}}"> Section 4</a></p>
+          <p>&bull;<a href="/walls/s5?options={{options}}"> Section 5</a></p>
         </div>
       </div>
     </div>

--- a/templates/create_boulder.html
+++ b/templates/create_boulder.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Navigation bar title-->
+    <title>Wall</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, text/html, charset=UTF-8"
+    />
+    <link href="../static/bootstrap.min.css" rel="stylesheet" media="screen" />
+    <link rel="stylesheet" href="../static/css/custom.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+    />
+    <!-- Development -->
+    <link rel="stylesheet" href="../static/css/all.css" />
+  </head>
+  <body>
+    <div id="holder">
+      <div id="body">
+        <div class="container">
+          <br />
+          <div>
+            {{ wall_name }}
+          </div>
+          <br />
+          <img
+            id="wall-image"
+            width="400"
+            src="{{ user_image }}"
+            alt="wall section"
+          />
+          <canvas id="wall-canvas"></canvas>
+          <br />
+          <br />
+          <div>
+            <row>
+              <button>Done</button>
+              <button>Cancel</button>
+            </row>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+
+<script>
+  var holds = [];
+  const RADIUS = 12;
+  window.onload = () => {
+    var img = document.getElementById("wall-image");
+    var cnvs = document.getElementById("wall-canvas");
+
+    cnvs.style.position = "absolute";
+    cnvs.style.left = img.offsetLeft + "px";
+    cnvs.style.top = img.offsetTop + "px";
+    cnvs.width = img.offsetWidth;
+    cnvs.height = img.offsetHeight;
+
+    var ctx = cnvs.getContext("2d");
+    ctx.width = cnvs.width;
+    ctx.height = cnvs.height;
+  };
+  document.addEventListener(
+    "click",
+    function(event) {
+      // If the clicked element doesn't have the right selector, bail
+      if (
+        !(
+          event.target.matches("#wall-image") ||
+          event.target.matches("#wall-canvas")
+        )
+      )
+        return;
+
+      // Don't follow the link
+      event.preventDefault();
+
+      // Log the clicked element in the console
+      Draw(event);
+    },
+    false
+  );
+
+  function Draw(event) {
+    var cnvs = document.getElementById("wall-canvas");
+    var ctx = cnvs.getContext("2d");
+    // Draw circle
+    ctx.beginPath();
+    ctx.arc(event.offsetX, event.offsetY, RADIUS, 0, 2 * Math.PI, false);
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = "#00ff00";
+    ctx.stroke();
+    holds.push({ x: event.offsetX, y: event.offsetY });
+    // console.log(holds);
+  }
+</script>

--- a/templates/create_route.html
+++ b/templates/create_route.html
@@ -48,6 +48,9 @@
 
 <script>
   var holds = [];
+  var HoldNum = 0;
+  const RADIUS = 12;
+  const MARGIN = 1;
   window.onload = () => {
     var img = document.getElementById("wall-image");
     var cnvs = document.getElementById("wall-canvas");
@@ -86,11 +89,21 @@
   function Draw(event) {
     var cnvs = document.getElementById("wall-canvas");
     var ctx = cnvs.getContext("2d");
+    // Draw circle
     ctx.beginPath();
-    ctx.arc(event.offsetX, event.offsetY, 12, 0, 2 * Math.PI, false);
+    ctx.arc(event.offsetX, event.offsetY, RADIUS, 0, 2 * Math.PI, false);
     ctx.lineWidth = 3;
     ctx.strokeStyle = "#00ff00";
     ctx.stroke();
+    // Draw text
+    ctx.font = "18px Georgia";
+    ctx.fillStyle = "red";
+    ctx.fillText(
+      HoldNum === 0 ? 'S' : HoldNum,
+      event.offsetX + RADIUS + MARGIN,
+      event.offsetY + RADIUS + MARGIN
+    );
+    HoldNum += 1;
     holds.push({ x: event.offsetX, y: event.offsetY });
     // console.log(holds);
   }

--- a/templates/home.html
+++ b/templates/home.html
@@ -21,7 +21,8 @@
           <div id="body">
             <div class="container">
               <br />
-              <p>&bull;<a href="/create"> Create</a></p>
+              <p>&bull;<a href="/create?options=boulder"> Create Boulder</a></p>
+              <p>&bull;<a href="/create?options=route"> Create Route</a></p>
               <p>&bull;<a href="/explore"> Explore</a></p>
             </div>
           </div>

--- a/templates/show_wall.html
+++ b/templates/show_wall.html
@@ -47,6 +47,10 @@
   cnvs.width = img.offsetWidth;
   cnvs.height = img.offsetHeight;
 
+  if (cnvs.height === 0) {
+    document.location.reload(true);
+  }
+
   var ctx = cnvs.getContext("2d");
   ctx.width = cnvs.width;
   ctx.height = cnvs.height;

--- a/templates/show_wall.html
+++ b/templates/show_wall.html
@@ -35,3 +35,20 @@
     </div>
   </body>
 </html>
+
+<script>
+  document.addEventListener(
+    "click",
+    function(event) {
+      // If the clicked element doesn't have the right selector, bail
+      if (!event.target.matches("#wall-image")) return;
+
+      // Don't follow the link
+      event.preventDefault();
+
+      // Log the clicked element in the console
+      console.log(event.target);
+    },
+    false
+  );
+</script>

--- a/templates/show_wall.html
+++ b/templates/show_wall.html
@@ -38,23 +38,20 @@
 </html>
 
 <script>
-  var img = document.getElementById("wall-image");
-  var cnvs = document.getElementById("wall-canvas");
+  window.onload = () => {
+    var img = document.getElementById("wall-image");
+    var cnvs = document.getElementById("wall-canvas");
 
-  cnvs.style.position = "absolute";
-  cnvs.style.left = img.offsetLeft + "px";
-  cnvs.style.top = img.offsetTop + "px";
-  cnvs.width = img.offsetWidth;
-  cnvs.height = img.offsetHeight;
+    cnvs.style.position = "absolute";
+    cnvs.style.left = img.offsetLeft + "px";
+    cnvs.style.top = img.offsetTop + "px";
+    cnvs.width = img.offsetWidth;
+    cnvs.height = img.offsetHeight;
 
-  if (cnvs.height === 0) {
-    document.location.reload(true);
-  }
-
-  var ctx = cnvs.getContext("2d");
-  ctx.width = cnvs.width;
-  ctx.height = cnvs.height;
-
+    var ctx = cnvs.getContext("2d");
+    ctx.width = cnvs.width;
+    ctx.height = cnvs.height;
+  };
   document.addEventListener(
     "click",
     function(event) {

--- a/templates/show_wall.html
+++ b/templates/show_wall.html
@@ -92,6 +92,6 @@
     ctx.strokeStyle = "#00ff00";
     ctx.stroke();
     holds.push({ x: event.offsetX, y: event.offsetY });
-    console.log(holds);
+    // console.log(holds);
   }
 </script>

--- a/templates/show_wall.html
+++ b/templates/show_wall.html
@@ -24,6 +24,7 @@
           <div>
             {{ wall_name }}
           </div>
+          <br />
           <img
             id="wall-image"
             width="400"
@@ -31,6 +32,14 @@
             alt="wall section"
           />
           <canvas id="wall-canvas"></canvas>
+          <br />
+          <br />
+          <div>
+            <row>
+              <button>Done</button>
+              <button>Cancel</button>
+            </row>
+          </div>
         </div>
       </div>
     </div>
@@ -38,6 +47,7 @@
 </html>
 
 <script>
+  var holds = [];
   window.onload = () => {
     var img = document.getElementById("wall-image");
     var cnvs = document.getElementById("wall-canvas");
@@ -81,5 +91,7 @@
     ctx.lineWidth = 3;
     ctx.strokeStyle = "#00ff00";
     ctx.stroke();
+    holds.push({ x: event.offsetX, y: event.offsetY });
+    console.log(holds);
   }
 </script>

--- a/templates/show_wall.html
+++ b/templates/show_wall.html
@@ -30,6 +30,7 @@
             src="{{ user_image }}"
             alt="wall section"
           />
+          <canvas id="wall-canvas"></canvas>
         </div>
       </div>
     </div>
@@ -37,18 +38,47 @@
 </html>
 
 <script>
+  var img = document.getElementById("wall-image");
+  var cnvs = document.getElementById("wall-canvas");
+
+  cnvs.style.position = "absolute";
+  cnvs.style.left = img.offsetLeft + "px";
+  cnvs.style.top = img.offsetTop + "px";
+  cnvs.width = img.offsetWidth;
+  cnvs.height = img.offsetHeight;
+
+  var ctx = cnvs.getContext("2d");
+  ctx.width = cnvs.width;
+  ctx.height = cnvs.height;
+
   document.addEventListener(
     "click",
     function(event) {
       // If the clicked element doesn't have the right selector, bail
-      if (!event.target.matches("#wall-image")) return;
+      if (
+        !(
+          event.target.matches("#wall-image") ||
+          event.target.matches("#wall-canvas")
+        )
+      )
+        return;
 
       // Don't follow the link
       event.preventDefault();
 
       // Log the clicked element in the console
       console.log(event.target);
+      Draw(event);
     },
     false
   );
+
+  function Draw(event) {
+    var ctx = cnvs.getContext("2d");
+    ctx.beginPath();
+    ctx.arc(event.offsetX, event.offsetY, 12, 0, 2 * Math.PI, false);
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = "#00ff00";
+    ctx.stroke();
+  }
 </script>

--- a/templates/show_wall.html
+++ b/templates/show_wall.html
@@ -67,13 +67,13 @@
       event.preventDefault();
 
       // Log the clicked element in the console
-      console.log(event.target);
       Draw(event);
     },
     false
   );
 
   function Draw(event) {
+    var cnvs = document.getElementById("wall-canvas");
     var ctx = cnvs.getContext("2d");
     ctx.beginPath();
     ctx.arc(event.offsetX, event.offsetY, 12, 0, 2 * Math.PI, false);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Add the basic drawing mechanics to define routes and boulders in the wall images.

## Current behavior before PR

Wall sections were loaded but no interaction with them was possible.

## Desired behavior after PR is merged

1. The user can choose whether a route or a boulder is to be set.
2. The user can draw the holds that form the route in the image by tapping them.
3. When defining a route holds are numbered, when defining a boulder they are not. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html