### PR TITLE
Add page to include new gyms

### DIFF
--- a/application.py
+++ b/application.py
@@ -300,10 +300,11 @@ def save_boulder():
     else:
         return abort(400)
 
-@login_required
+# route decorator should be the outermost decorator
 @app.route('/add_gym', methods=['GET', 'POST'])
+@login_required
 def add_gym():
-    redirect(url_for('home'))
+    return render_template('add_new_gym.html')
 
 # Login handlers
 @app.route('/login', methods=['GET', 'POST'])

--- a/templates/add_new_gym.html
+++ b/templates/add_new_gym.html
@@ -6,7 +6,7 @@
     <div id="holder">
       <div id="body">
         <div class="container" style="margin-top: 1rem;">
-            This page is where new Gym additions will pe performed
+            This page is where new Gym additions will be performed
         </div>
       </div>
     </div>

--- a/templates/add_new_gym.html
+++ b/templates/add_new_gym.html
@@ -1,0 +1,13 @@
+{% extends "base_template.html" %}
+
+{% block title %}Add new Gym{% endblock %}
+
+{% block content %}
+    <div id="holder">
+      <div id="body">
+        <div class="container" style="margin-top: 1rem;">
+            This page is where new Gym additions will pe performed
+        </div>
+      </div>
+    </div>
+{% endblock %}

--- a/templates/add_new_gym.html
+++ b/templates/add_new_gym.html
@@ -6,7 +6,7 @@
     <div id="holder">
       <div id="body">
         <div class="container" style="margin-top: 1rem;">
-            This page is where new Gym additions will be performed
+            This page is where new Gym additions will be performed, and it is accessible only for registered users
         </div>
       </div>
     </div>

--- a/templates/base_template.html
+++ b/templates/base_template.html
@@ -22,6 +22,9 @@
 <div class="container">
     <ul class="user-info">
         <li><a href="{{ url_for('home') }}">Home</a></li>
+        <li> | </li>
+        <li><a href="{{ url_for('add_gym') }}">Add your Gym</a></li>
+        <li> | </li>
         {% if current_user.is_anonymous %}
             <li><a href="{{ url_for('login') }}">Login</a></li>
             <li> | </li>

--- a/templates/login_form.html
+++ b/templates/login_form.html
@@ -6,20 +6,38 @@
     <div class="container" style="margin-top: 1rem;">
         <form action="" method="post" novalidate>
             {{ form.hidden_tag() }}
+            <div class="row">
+                <div class="col-6">
+                    <div style="width: 50%;">
+                        {{ form.email.label }}
+                    </div>
+                    <div style="width: 50%;">
+                        {{ form.email }}
+                    </div>
+                </div>
+            </div>
             <div>
-                {{ form.email.label }}
-                {{ form.email }}<br>
                 {% for error in form.email.errors %}
                 <span style="color: red;">{{ error }}</span>
                 {% endfor %}
             </div>
+            <br>
+            <div class="row">
+                <div class="col-6">
+                    <div style="width: 50%;">
+                        {{ form.password.label }}
+                    </div>
+                    <div style="width: 50%;">
+                    {{ form.password }}
+                    </div>
+                </div>
+            </div>
             <div>
-                {{ form.password.label }}
-                {{ form.password }}<br>
                 {% for error in form.password.errors %}
                 <span style="color: red;">{{ error }}</span>
                 {% endfor %}
             </div>
+            <br>
             <div>{{ form.remember_me() }} {{ form.remember_me.label }}</div>
             <div>
                 {{ form.submit() }}

--- a/templates/login_form.html
+++ b/templates/login_form.html
@@ -44,5 +44,6 @@
             </div>
         </form>
     </div>
+    <br>
     <div class="container">¿Don't have an account? <a href="{{ url_for('show_signup_form') }}">Sign up</a></div>
 {% endblock %}

--- a/templates/signup_form.html
+++ b/templates/signup_form.html
@@ -9,27 +9,54 @@
     {% endif %}
     <form action="" method="post" novalidate>
         {{ form.hidden_tag() }}
+        <div class="row">
+            <div class="col-6">
+                <div style="width: 50%;">
+                    {{ form.name.label }}
+                </div>
+                <div style="width: 50%;">
+                    {{ form.name }}
+                </div>
+            </div>
+        </div>
         <div>
-            {{ form.name.label }}
-            {{ form.name(size=64) }}<br>
             {% for error in form.name.errors %}
             <span style="color: red;">{{ error }}</span>
             {% endfor %}
         </div>
+        <br>
+        <div class="row">
+            <div class="col-6">
+                <div style="width: 50%;">
+                    {{ form.email.label }}
+                </div>
+                <div style="width: 50%;">
+                    {{ form.email }}
+                </div>
+            </div>
+        </div>
         <div>
-            {{ form.email.label }}
-            {{ form.email }}<br>
             {% for error in form.email.errors %}
             <span style="color: red;">{{ error }}</span>
             {% endfor %}
         </div>
+        <br>
+        <div class="row">
+            <div class="col-6">
+                <div style="width: 50%;">
+                    {{ form.password.label }}
+                </div>
+                <div style="width: 50%;">
+                    {{ form.password }}
+                </div>
+            </div>
+        </div>
         <div>
-            {{ form.password.label }}
-            {{ form.password }}<br>
             {% for error in form.password.errors %}
             <span style="color: red;">{{ error }}</span>
             {% endfor %}
         </div>
+        <br>
         <div>
             {{ form.submit() }}
         </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is just a test and adds the basic mechanics, but further work is required on the Add New Gym page. What this PR adds is:

1. Improve Log In and Sign Up forms style.
2. Add new link to topbar navigation links (which appear on all pages) that points to the Add New Gym page
3. Add a new sketch page, protected by login, that is only visible to registered users. This page currently has no logic, but should enable registered users to add new gyms.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html