### PR TITLE
Add notes field to boulders

### DIFF
--- a/application.py
+++ b/application.py
@@ -14,7 +14,7 @@ from werkzeug.urls import url_parse
 import pymongo
 import db.mongodb_controller as db_controller
 from config import *
-import utils
+from utils import utils
 
 import ticklist_handler
 
@@ -333,14 +333,14 @@ def wall_section(wall_section):
 @app.route('/save', methods=['POST'])
 def save():
     """
-    Save page handler.
+    Save page handler
     """
     if request.method == 'POST':
         data = {'rating': 0, 'raters': 0}
         for key, val in request.form.items():
-            data[key] = val
-            if key == 'holds':
-                data[key] = ast.literal_eval(val)
+            data[key.lower()] = val
+            if key.lower() == 'holds':
+                data[key.lower()] = ast.literal_eval(val)
         data['time'] = datetime.datetime.now().isoformat()
         db_controller.put_boulder(data, gym=get_gym(), database=get_db())
     return redirect('/')

--- a/templates/explore_boulders.html
+++ b/templates/explore_boulders.html
@@ -61,8 +61,8 @@
             <!-- TODO: Add safename field to boulder -->
             <div style="padding-left: 0.5rem;">
               <form action="/load_boulder" method="post">
-                <input type="hidden" name="boulder_data" id="holds-array" value="{{boulder}}" />
-                <input type="hidden" name="origin" id="origin" value="explore_boulders" />
+                <input type="hidden" name="boulder_data" id="{{ boulder['_id'] + boulder['name'] }}" value="{{boulder}}" />
+                <input type="hidden" name="origin" id="{{ boulder['name'] + boulder['_id'] }}" value="explore_boulders" />
                 <button type="submit" name="boulder" value="{{ boulder['name'] }}" class="btn-link">
                   <h5>{{boulder['name']}}</h5>
                 </button>

--- a/templates/load_boulder.html
+++ b/templates/load_boulder.html
@@ -31,6 +31,19 @@
           <img id="wall-image" src="{{ wall_image }}" alt="wall section" />
           <canvas id="wall-canvas"></canvas>
           <br />
+          {% if  boulder_data.get('notes', '') %}
+          <div class="container">
+            <div class="row d-flex justify-content-center">
+              <p>
+                <b>Notes:</b>
+              </p>
+              <div class="col-lg-12 d-flex justify-content-center">
+                {{ boulder_data.get('notes', '') }}
+              </div>
+            </div>
+            </div>
+           <br />
+           {% endif %}
           <div class="container">
             <div class="row d-flex justify-content-center">
               <div class="col-lg-12 d-flex justify-content-center">

--- a/templates/load_boulder.html
+++ b/templates/load_boulder.html
@@ -30,11 +30,11 @@
           <br />
           <img id="wall-image" src="{{ wall_image }}" alt="wall section" />
           <canvas id="wall-canvas"></canvas>
-          <br />
+          <hr width="50%" style="margin-bottom: 0.5rem; margin-top: 0.5rem;"/>
           {% if  boulder_data.get('notes', '') %}
           <div class="container">
             <div class="row d-flex justify-content-center">
-              <p>
+              <p style="margin-top: 0; margin-bottom: 0.5rem;">
                 <b>Notes:</b>
               </p>
               <div class="col-lg-12 d-flex justify-content-center">
@@ -42,7 +42,7 @@
               </div>
             </div>
             </div>
-           <br />
+           <hr width=50% style="margin-bottom: 0.5rem; margin-top: 0.5rem;"/>
            {% endif %}
           <div class="container">
             <div class="row d-flex justify-content-center">
@@ -280,8 +280,11 @@
 
   @media (max-width: 600px) {
     .star-rating {
-      line-height: 15px;
+      /* line-height: 15px; */
       font-size: 0.8em;
+    }
+    hr {
+      width: 95%;
     }
   }
 </style>

--- a/templates/save_boulder.html
+++ b/templates/save_boulder.html
@@ -65,6 +65,9 @@
                 <input type="radio" name="feet" value="free" /> Free Feet<br />
                 <input type="radio" name="feet" value="no-feet" />
                 Campus<br /><br />
+                Notes:<br />
+                <textarea rows="5" cols="26" name="Notes"></textarea>
+                <br/><br />
                 <input type="submit" value="Submit" />
                 <input
                   type="hidden"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

#53 

## Current behavior before PR

There wasn't the option to add notes to a boulder

## Desired behavior after PR is merged

Boulder creator can add notes to a problem when creating it and they are shown later to any user that loads the problem

![imagen](https://user-images.githubusercontent.com/9968427/123520065-2139f780-d6af-11eb-924f-c8ab66e93434.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html