### PR TITLE
Fix dates climbed visualization

### DIFF
--- a/templates/tick_list.html
+++ b/templates/tick_list.html
@@ -110,16 +110,16 @@
             </div>
             <div class="col-4" style="display: flex; justify-content: right;">
               {%- if boulder['is_done'] -%}
-              <div class="col-4">
+              <div>
                 <span id="date-climbed">Dates Climbed:</span>
+                {%- for date in boulder['date_climbed'] -%}
+                <div style="display: flex; flex-direction: row;">
+                  <span class="date-climbed-span">
+                    {{ date }}
+                  </span>
+                </div>
+                {% endfor %}
               </div>
-              {%- for date in boulder['date_climbed'] -%}
-              <div class="col-8" style="display: flex; flex-direction: column;">
-                <span class="date-climbed-span">
-                  {{ date }}
-                </span>
-              </div>
-              {% endfor %}
               {%- endif -%}
             </div>
           </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #96 

## Current behavior before PR

Dates climbed were listed on one row, different columns

## Desired behavior after PR is merged

Dates climbed are listed all in a single column, different rows


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1].

[1]: https://www.python.org/dev/peps/pep-0008
