### PR TITLE
Increase maxlength of boulder name and creator

### DIFF
--- a/templates/save_boulder.html
+++ b/templates/save_boulder.html
@@ -29,9 +29,9 @@
 
           <form action="/save" onsubmit="return validateForm()" method="POST">
             Boulder name:<br />
-            <input id="name-field" type="text" name="name" value="" maxlength="26" required /><br /><br />
+            <input id="name-field" type="text" name="name" value="" maxlength="60" required /><br /><br />
             Creator:<br />
-            <input id="creator-field" type="text" name="creator" value="{{ username }}" maxlength="26"
+            <input id="creator-field" type="text" name="creator" value="{{ username }}" maxlength="60"
               required /><br /><br />
             Suggested difficulty:<br />
             <input type="radio" name="difficulty" value="green" checked />


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #97 

## Current behavior before PR

Name and creator fields when creating a new boulder had a max length of 26.

## Desired behavior after PR is merged

Increase the max length of the creator and name fields to 60.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1].

[1]: https://www.python.org/dev/peps/pep-0008
