### PR TITLE
Fix hardcoded gym id when non selected

### DIFF
--- a/application.py
+++ b/application.py
@@ -89,7 +89,8 @@ def get_gym() -> str:
     """
     if session.get('gym', ''):
         return session['gym']
-    return 'sancu'
+    gyms = db_controller.get_gyms(get_db())
+    return gyms[0]['id']
 
 
 @app.route('/', methods=['GET', 'POST'])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Default gym name is hardcoded, generating an error when using a personnal database

## Current behavior before PR

Website crash when the hardcoded gym doesn't exist

## Desired behavior after PR is merged

The default gym is set to the first gym found in the database
