### PR TITLE
Fix: 108 - Going back from random problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ Once the container is up and running, the app can be accessed at http://localhos
 ## Links of interest
 
 * [Yolo Bouldering](https://github.com/yarkhinephyo/yolo_bouldering)
+* [Climbnet](https://github.com/cydivision/climbnet)

--- a/application.py
+++ b/application.py
@@ -310,7 +310,7 @@ def random_problem() -> str:
         boulder_name=boulder_name,
         wall_image=wall_image,
         boulder_data=boulder,
-        origin=request.form.get('origin', 'home'),
+        origin=request.form.get('origin', ''),
         hold_data=hold_data
     )
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #108 

## Current behavior before PR

Navigating back from the random problem url raises a 404 error

## Desired behavior after PR is merged

Navigating back from the random problem url goes back to the homepage

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1].

[1]: https://www.python.org/dev/peps/pep-0008
