### PR TITLE
Use command-line argument for DOCKER_ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:20.04
 
 # to prevent debconf from asking questions
 ENV DEBIAN_FRONTEND=noninteractive
-ENV DOCKER_ENV=True 
 
 LABEL maintainer="Juan Gallostra <juangallostra@gmail.com>"
 
@@ -18,4 +17,4 @@ RUN python3.9 -m pip install --no-cache-dir -r requirements.txt
 
 COPY . /rocolib
 
-CMD [ "python3.9", "./application.py" ]
+CMD [ "python3.9", "./application.py", "docker" ]

--- a/README.md
+++ b/README.md
@@ -93,15 +93,7 @@ Once the container is up and running, the app can be accessed at http://localhos
    ```
 3. Set up [MongoDB](https://www.mongodb.com). This can either be a local instance of MongoDB or an instance running on the cloud. We are currently using MongoDB Atlas free tier.
 4. Configure MongoDB connection so that the application code can talk with the DDBB.
-5. Set required environment variables. On windows, if you just want to set them for the current session:
-   ```
-   $env:DOCKER_ENV="False"
-   ```
-   Alternatively, if you want to set them permamently -You will need admin privileges and a terminal restart after executing the command-:
-   ```
-   [Environment]::SetEnvironmentVariable("DOCKER_ENV", "False", "Machine")
-   ```
-6. Run
+5. Run
    ```
    python application.py
    ```

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,6 +1,6 @@
 import os
 
-from config import PORT
+from config import PORT, DOCKER_ENV
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
@@ -10,7 +10,7 @@ from marshmallow import Schema, fields
 
 host = 'http://localhost:'
 localhost_port = PORT
-if os.environ['DOCKER_ENV'] == "True":
+if DOCKER_ENV == "True":
     localhost_port = 9090
 
 

--- a/application.py
+++ b/application.py
@@ -536,7 +536,7 @@ if __name__ == '__main__':
         generate_api_docs(app)
     if RUN_SERVER:
         set_creds_file(CREDS)
-        if os.environ['DOCKER_ENV'] == "True":
+        if DOCKER_ENV == "True":
             app.run(debug=DEBUG, host='0.0.0.0', port=80)
         else:
             app.run(debug=DEBUG, port=PORT)

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+from sys import argv
+
 CREDS = 'creds.txt'
 CREDS_DEV = 'creds_dev.txt'
 
@@ -6,6 +8,10 @@ PORT = 5050
 DB_NAME = 'RocoLib'
 WALLS_PATH = 'images/walls/'
 ITEMS = 'Items'
+
+DOCKER_ENV="False"
+if len(argv) > 1 and str(argv[1]) == "docker":
+    DOCKER_ENV="True"
 
 BOULDER_COLOR_MAP = {
     'green': '#2CC990',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Set DOCKER_ENV by happening "docker" at command-line argument instead of environment variables

Using environment variables is not very handy.  Command-line arguments seems to me a better solution. It may also be used for other stuff in the futur (like setting DEBUG, this kind of things).