### PR TITLE
Fix ticklist problem visualization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 Features
 --------
 
+- #128 Fix fields rendering in user's ticklist problem cards
 - #127 Show problems as collapsible cards in problem lists
 - #125 Add wall versioning, list only latest sets for problem creation
 - #123 Add changelog

--- a/templates/tick_list.html
+++ b/templates/tick_list.html
@@ -83,7 +83,7 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-8" style="padding-left: 0;">
+            <div class="col-8" style="padding-left: 0px; padding-right: 0px;">
               <ul>
                 {%- for wall in walls_list -%}
                 {%- if wall['image'] == boulder['section'] -%}
@@ -95,7 +95,7 @@
                 <li>
                   <div class="container">
                     <div class="row d-flex justify-content-left">
-                      <div class="col-lg-12 d-flex justify-content-left" style="padding-left: 0px;">
+                      <div class="col-lg-12 d-flex justify-content-left" style="padding-left: 0px; padding-right:0px;">
                         <div class="star-rating-fixed">
                           <span class="{{ 'fa fa-star' if boulder.get('rating', 0) < 1 else 'fas fa-star' }}"></span>
                           <span class="{{ 'fa fa-star' if boulder.get('rating', 0) < 2 else 'fas fa-star' }}"></span>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

As shown in the image below, some of the problem fields (such as the rating) are not properly rendered.

![imagen](https://user-images.githubusercontent.com/9968427/166413706-c10fbc54-6fc6-47af-8a0c-a301dca20ecd.png)

## Current behavior before PR

Bad rendering of problem fields in ticklist.

## Desired behavior after PR is merged

Problem fields are properly rendered.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1].

[1]: https://www.python.org/dev/peps/pep-0008
