### PR TITLE
feature: Add feet marker on problem creation

### DIFF
--- a/language/en_US.json
+++ b/language/en_US.json
@@ -71,5 +71,6 @@
     "random_problem": "Random Problem",
     "stats": "Stats",
     "repetitions": "Repetitions",
-    "contact": "Contact"
+    "contact": "Contact",
+    "feet_only": "Feet"
 }

--- a/language/es_ES.json
+++ b/language/es_ES.json
@@ -71,5 +71,6 @@
     "random_problem": "Problema Aleatorio",
     "stats": "Estadísticas",
     "repetitions": "Repeticiones",
-    "contact": "Contacto"
+    "contact": "Contacto",
+    "feet_only": "Pie"
 }

--- a/language/fr_FR.json
+++ b/language/fr_FR.json
@@ -70,5 +70,6 @@
     "random_problem": "Bloc au Hasard",
     "stats_": "Statistiques",
     "repetitions": "Répétitions",
-    "contact": "Contactez"
+    "contact": "Contactez",
+    "feet_only": "Pied"
 }

--- a/templates/create_boulder.html
+++ b/templates/create_boulder.html
@@ -48,15 +48,19 @@
             <div style="text-align: center;">
               <h6>{{ hold_type }}</h6>
               <div class="row">
-                <div class="col-4">
+                <div class="col" style="display: flex; align-items:center; justify-content:center;">
                   <input type="radio" name="hold_type" value="#00ff00" checked />
                   {{ start }}<br />
                 </div>
-                <div class="col-4">
+                <div class="col" style="display: flex; align-items:center; justify-content:center;">
                   <input type="radio" name="hold_type" value="#0000ff" />
                   {{ normal }}<br />
                 </div>
-                <div class="col-4">
+                <div class="col" style="display: flex; align-items:center; justify-content:center;">
+                  <input type="radio" name="hold_type" value="#ffa321" />
+                  {{ feet_only }}<br />
+                </div>
+                <div class="col" style="display: flex; align-items:center; justify-content:center;">
                   <input type="radio" name="hold_type" value="#ff0000" />
                   {{ top }}<br />
                 </div>
@@ -120,8 +124,8 @@
       margin-right: auto;
     }
     
-    h5 {
-      margin-top: 0.5rem;
+    h6 {
+      margin-top: 1rem;
     }
   }
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Related issue: #141 

## Current behavior before PR

There was no option to specify a feet only hold.

## Desired behavior after PR is merged

There is a new option to specify a feet only hold.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1].

[1]: https://www.python.org/dev/peps/pep-0008
