### PR TITLE
Fix: Image load on gym change

### DIFF
--- a/application.py
+++ b/application.py
@@ -242,6 +242,7 @@ def change_gym_problem_list() -> str:
     Load the list of problems for the selected gym
     """
     gym = request.form.get('gym', get_gym())
+    session['gym'] = gym
     filters = session.get('filters', None)
 
     boulders = utils.get_boulders_list(gym, filters, g.db, session)

--- a/templates/create_route.html
+++ b/templates/create_route.html
@@ -16,10 +16,8 @@
       <br />
       <br />
       <div>
-        <row>
           <button>{{ done }}</button>
           <button>{{ cancel }}</button>
-        </row>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When changing gym from problem list images were not properly loaded.

## Current behavior before PR

Problems didn't load properly after a gym change

## Desired behavior after PR is merged

Problems are properly loaded after a gym change

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1].

[1]: https://www.python.org/dev/peps/pep-0008
