### PR TITLE
Fix 180: image download of a problem

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ Features
 Fixes
 -----
 
+- #185 Fix downloading a problem as an image 
 - #184 Spacing between radio button and text in hold selection options when creating a problem
 - #183 Display correct text in hold detection text label on the problem creation page 
 - #170 Take into account latest wall set flag when swiping problems

--- a/static/js/problem_utils.js
+++ b/static/js/problem_utils.js
@@ -278,7 +278,7 @@ function downloadProblem(boulder_name, image_wall) {
   var downloadCanvas = document.createElement('canvas');
   var img_ref = document.getElementById('wall-image')
 
-  document.getElementById('wrapper').insertBefore(downloadCanvas, img_ref);
+  document.getElementById('problem-wrapper').insertBefore(downloadCanvas, img_ref);
 
   downloadCanvas.id = "download-canvas";
   downloadCanvas.style.position = "absolute";

--- a/templates/load_boulder.html
+++ b/templates/load_boulder.html
@@ -48,7 +48,7 @@
         <label class="custom-control-label" for="holdDetectionSwitch">{{ hold_detection_ }}</label>
       </div>
       <br />
-      <div class="row" style="padding-left: 15px; padding-right: 15px;">
+      <div class="row" id="problem-wrapper" style="padding-left: 15px; padding-right: 15px;">
           <div class="pc-arrow-left">
             <a class="btn btn-outline-primary" href="#" onclick="clicked_previous()" role="button">
               <i class="fa fa-chevron-left" aria-hidden="true"></i>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Related issue: #180

## Current behavior before PR

Trying to download a problem as an image raised an error

## Desired behavior after PR is merged

It is possible to download a problem as an image

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1].

[1]: https://www.python.org/dev/peps/pep-0008
